### PR TITLE
Royal regimen fixes (#463)

### DIFF
--- a/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
+++ b/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
@@ -1216,7 +1216,7 @@
     "_Id": 30170008,
     "_MissionType": "Drill",
     "_MissionId": 301700,
-    "_CompleteType": "AbilityCrestTotalPlusCountUp",
+    "_CompleteType": "AbilityCrestLevelUp",
     "_UseTotalValue": 1
   },
   {
@@ -1332,7 +1332,7 @@
     "_MissionId": 303000,
     "_CompleteType": "QuestCleared",
     "_UseTotalValue": 1,
-    "_Parameter": 210010101,
+    "_Parameter": 210011101,
     "_Parameter3": 2
   },
   {

--- a/DragaliaAPI/Features/GraphQL/MissionMutations.cs
+++ b/DragaliaAPI/Features/GraphQL/MissionMutations.cs
@@ -15,39 +15,34 @@ public class MissionMutations(
     IMissionService missionService,
     IMissionInitialProgressionService missionInitialProgressionService,
     ApiContext apiContext,
-    IPlayerIdentityService playerIdentityService
+    IPlayerIdentityService playerIdentityService,
+    ILogger<MissionMutations> logger
 ) : MutationBase(apiContext, playerIdentityService)
 {
     [GraphQLMutation("Reset a mission to its initial progress")]
     public async Task<Expression<Func<ApiContext, DbPlayerMission>>> ResetMissionProgress(
         ApiContext db,
-        MissionMutationArgs args
+        MissionPlayerMutationArgs args
     )
     {
         DbPlayer player = GetPlayer(args.ViewerId);
-
-        DbPlayerMission mission =
-            await db.PlayerMissions.FindAsync(player.AccountId, args.MissionType, args.MissionId)
-            ?? throw new InvalidOperationException("Mission not found");
+        DbPlayerMission mission = GetMission(db, player, args);
 
         await missionInitialProgressionService.GetInitialMissionProgress(mission);
 
         await db.SaveChangesAsync();
 
-        return ctx => ctx.PlayerMissions.Find(player.AccountId, args.MissionType, args.MissionId)!;
+        return this.GetMissionExpression(player, args);
     }
 
     [GraphQLMutation("Completes a mission")]
     public async Task<Expression<Func<ApiContext, DbPlayerMission>>> CompleteMission(
         ApiContext db,
-        MissionMutationArgs args
+        MissionPlayerMutationArgs args
     )
     {
         DbPlayer player = GetPlayer(args.ViewerId);
-
-        DbPlayerMission mission =
-            await db.PlayerMissions.FindAsync(player.AccountId, args.MissionType, args.MissionId)
-            ?? throw new InvalidOperationException("Mission not found");
+        DbPlayerMission mission = GetMission(db, player, args);
 
         if (mission.State != MissionState.InProgress)
             throw new InvalidOperationException("Mission was already completed");
@@ -59,13 +54,13 @@ public class MissionMutations(
 
         await db.SaveChangesAsync();
 
-        return ctx => ctx.PlayerMissions.Find(player.AccountId, args.MissionType, args.MissionId)!;
+        return this.GetMissionExpression(player, args);
     }
 
     [GraphQLMutation("Starts a mission")]
     public async Task<Expression<Func<ApiContext, DbPlayerMission>>> StartMission(
         ApiContext db,
-        MissionMutationArgs args
+        MissionPlayerMutationArgs args
     )
     {
         if (args.MissionType is MissionType.Drill or MissionType.MainStory)
@@ -76,12 +71,7 @@ public class MissionMutations(
         }
 
         DbPlayer player = GetPlayer(args.ViewerId);
-
-        DbPlayerMission? mission = await db.PlayerMissions.FindAsync(
-            player.AccountId,
-            args.MissionType,
-            args.MissionId
-        );
+        DbPlayerMission mission = GetMission(db, player, args);
 
         if (mission != null)
             throw new InvalidOperationException("Mission is already started");
@@ -90,13 +80,75 @@ public class MissionMutations(
 
         await db.SaveChangesAsync();
 
-        return ctx => ctx.PlayerMissions.Find(player.AccountId, args.MissionType, args.MissionId)!;
+        return this.GetMissionExpression(player, args);
+    }
+
+    [GraphQLMutation("Reset a mission's progress for all players")]
+    public async Task<Expression<Func<ApiContext, IEnumerable<DbPlayerMission>>>> ResetAllProgress(
+        ApiContext db,
+        MissionMutationArgs args
+    )
+    {
+        List<DbPlayerMission> affectedMissions = await db.PlayerMissions
+            .Where(
+                x =>
+                    x.Id == args.MissionId
+                    && x.Type == args.MissionType
+                    && x.State == MissionState.InProgress
+            )
+            .ToListAsync();
+
+        string[] players = affectedMissions.Select(x => x.DeviceAccountId).ToArray();
+
+        foreach (DbPlayerMission mission in affectedMissions)
+        {
+            logger.LogInformation(
+                "Recalculating progress for player {accountId}",
+                mission.DeviceAccountId
+            );
+
+            using IDisposable ctx = playerIdentityService.StartUserImpersonation(
+                mission.DeviceAccountId
+            );
+
+            await missionInitialProgressionService.GetInitialMissionProgress(mission);
+        }
+
+        await db.SaveChangesAsync();
+
+        return context =>
+            context.PlayerMissions.Where(
+                x =>
+                    players.Contains(x.DeviceAccountId)
+                    && x.Id == args.MissionId
+                    && x.Type == args.MissionType
+            );
     }
 
     [GraphQLArguments]
     public record MissionMutationArgs(
-        long ViewerId,
         [property: JsonConverter(typeof(JsonStringEnumConverter))] MissionType MissionType,
         int MissionId
     );
+
+    [GraphQLArguments]
+    public record MissionPlayerMutationArgs(long ViewerId, MissionType MissionType, int MissionId)
+        : MissionMutationArgs(MissionType, MissionId);
+
+    private Expression<Func<ApiContext, DbPlayerMission>> GetMissionExpression(
+        DbPlayer player,
+        MissionMutationArgs args
+    ) => context => GetMission(context, player, args);
+
+    private DbPlayerMission GetMission(
+        ApiContext context,
+        DbPlayer player,
+        MissionMutationArgs args
+    ) =>
+        context.PlayerMissions.FirstOrDefault(
+            x =>
+                x.Id == args.MissionId
+                && x.Type == args.MissionType
+                && x.DeviceAccountId == player.AccountId
+        ) ?? throw new InvalidOperationException("No mission found.");
 }


### PR DESCRIPTION
- Fix 'Clear High Midgardsormr's Trial: Standard on Solo' counting the co-op version
- Fix 'Upgrade a Wyrmprint's HP & Strength 15 Times' counting augment usage instead of water usage
- Fix 'Obtain Glorious Tempest from the Treasure Trade' not being able to be completed for pre-2.0 saves
- Fix existing GraphQL mutations
- Add new GraphQL 'reset all' mutation when fixes are applied to a particular mission