### PR TITLE
Add stub album implementation (#474)

### DIFF
--- a/DragaliaAPI/Controllers/Dragalia/WeaponBodyController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/WeaponBodyController.cs
@@ -79,7 +79,12 @@ public class WeaponBodyController : DragaliaControllerBase
 
             if (buildupResult != ResultCode.Success)
             {
-                this.logger.LogError("buildup_piece request {request} was invalid", request);
+                this.logger.LogError(
+                    "buildup_piece request {@request} was invalid: {result}",
+                    request,
+                    buildupResult
+                );
+
                 return this.Code(buildupResult);
             }
         }

--- a/DragaliaAPI/Features/Album/AlbumController.cs
+++ b/DragaliaAPI/Features/Album/AlbumController.cs
@@ -1,0 +1,25 @@
+using DragaliaAPI.Controllers;
+using DragaliaAPI.Models.Generated;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DragaliaAPI.Features.Album;
+
+[Route("album")]
+public class AlbumController : DragaliaControllerBase
+{
+    [HttpPost("index")]
+    public DragaliaResult Index()
+    {
+        AlbumIndexData stubResponse =
+            new()
+            {
+                album_dragon_list = Enumerable.Empty<AlbumDragonData>(),
+                album_quest_play_record_list = Enumerable.Empty<AtgenAlbumQuestPlayRecordList>(),
+                chara_honor_list = Enumerable.Empty<AtgenCharaHonorList>(),
+                album_passive_update_result = new(),
+                update_data_list = new()
+            };
+
+        return this.Ok(stubResponse);
+    }
+}


### PR DESCRIPTION
This controller which does not return any actual data should prevent the game from softlocking when attempting to access Notte's Notes.